### PR TITLE
Patch the scikit-learn Imputer import

### DIFF
--- a/magpysv/denoise.py
+++ b/magpysv/denoise.py
@@ -19,7 +19,7 @@ from sklearn.decomposition import PCA as sklearnPCA
 try:
     from sklearn.preprocessing import Imputer
 except ImportError:
-    from sklearn.imput import SimpleImputer as Imputer
+    from sklearn.impute import SimpleImputer as Imputer
 
 
 def eigenvalue_analysis_impute(*, dates, obs_data, model_data, residuals,

--- a/magpysv/denoise.py
+++ b/magpysv/denoise.py
@@ -16,7 +16,10 @@ import pandas as pd
 import magpysv.plots as plots
 import numpy as np
 from sklearn.decomposition import PCA as sklearnPCA
-from sklearn.preprocessing import Imputer
+try:
+    from sklearn.preprocessing import Imputer
+except ImportError:
+    from sklearn.imput import SimpleImputer as Imputer
 
 
 def eigenvalue_analysis_impute(*, dates, obs_data, model_data, residuals,


### PR DESCRIPTION
Adds a `try/except` block to the import to make it compatible with scikit-learn > 0.22. The name and module of the `Imputer` class changed but the behavior should still be the same. 

This was causing issues installing magpysv on Anaconda Python 3.8 since the older scikit-learn compiled packages only exist for 3.7. 